### PR TITLE
feat: get amount of users that follow a seller user (US0003)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+target
+.idea
+*.DS_Store

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/ProductController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/ProductController.java
@@ -1,0 +1,8 @@
+package com.mercadolibre.be_java_hisp_w31_g04.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+
+public class ProductController {
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/RemoveThisController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/RemoveThisController.java
@@ -1,5 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.controller;
-
-public class RemoveThisController {
-
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -2,12 +2,14 @@ package com.mercadolibre.be_java_hisp_w31_g04.controller;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -28,4 +30,8 @@ public class UserController {
         return new ResponseEntity<>(userServiceImpl.getUserFollowersCount(userId), HttpStatus.OK);
     }
 
+    @GetMapping("/{userId}/followers/list")
+    public ResponseEntity<UserWithFollowersDto> getUserFollowers(@PathVariable int userId){
+        return new ResponseEntity<>(userServiceImpl.getUserWithFollowed(userId), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -3,6 +3,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.controller;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
+import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +13,10 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/users")
 public class UserController {
 
-    @Autowired
-    UserServiceImpl userServiceImpl;
+    IUserService userServiceImpl;
+    public UserController(UserServiceImpl userServiceImpl){
+        this.userServiceImpl = userServiceImpl;
+    }
 
     @GetMapping("/{userId}/followed/list")
     public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.mercadolibre.be_java_hisp_w31_g04.controller;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    UserServiceImpl userServiceImpl;
+
+    @GetMapping("/{userId}/followed/list")
+    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId){
+        return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -5,10 +5,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -18,8 +15,8 @@ public class UserController {
     UserServiceImpl userServiceImpl;
 
     @GetMapping("/{userId}/followed/list")
-    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId){
-        return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId), HttpStatus.OK);
+    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {
+        return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId,order), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.mercadolibre.be_java_hisp_w31_g04.controller;
 
+import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,11 @@ public class UserController {
     @GetMapping("/{userId}/followed/list")
     public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {
         return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId,order), HttpStatus.OK);
+    }
+
+    @GetMapping("/{userId}/followers/count")
+    public ResponseEntity<FollowersCountDto> getUserFollowersCount(@PathVariable int userId){
+        return new ResponseEntity<>(userServiceImpl.getUserFollowersCount(userId), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/ExceptionDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/ExceptionDto.java
@@ -1,0 +1,12 @@
+package com.mercadolibre.be_java_hisp_w31_g04.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ExceptionDto {
+    private String message;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/FollowersCountDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/FollowersCountDto.java
@@ -1,0 +1,12 @@
+package com.mercadolibre.be_java_hisp_w31_g04.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class FollowersCountDto {
+    private int user_id;
+    private String user_name;
+    private int followers_count;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/RemoveThisDTO.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/RemoveThisDTO.java
@@ -1,5 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.dto;
-
-public class RemoveThisDTO {
-
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserFollowedDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserFollowedDto.java
@@ -1,0 +1,23 @@
+package com.mercadolibre.be_java_hisp_w31_g04.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class UserFollowedDto {
+    private int user_id;
+    private String user_name;
+    private List<UserFollowedDto> followed;
+
+    public UserFollowedDto(int id, String name) {
+        this.user_id = id;
+        this.user_name = name;
+        followed = null;
+    }
+}
+

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
@@ -1,0 +1,18 @@
+package com.mercadolibre.be_java_hisp_w31_g04.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserWithFollowersDto {
+    private int user_id;
+    private String user_name;
+    private List<UserFollowedDto> followers;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/ExceptionController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/ExceptionController.java
@@ -1,0 +1,18 @@
+package com.mercadolibre.be_java_hisp_w31_g04.exception;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.ExceptionDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionController {
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<?> notFound(NotFoundException e){
+        ExceptionDto exceptionDto = new ExceptionDto(e.getMessage());
+        return new ResponseEntity<>(exceptionDto, HttpStatus.NOT_FOUND);
+    }
+
+
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/NotFoundException.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.mercadolibre.be_java_hisp_w31_g04.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/RemoveThisException.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/exception/RemoveThisException.java
@@ -1,5 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.exception;
-
-public class RemoveThisException {
-
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/Post.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/Post.java
@@ -1,0 +1,15 @@
+package com.mercadolibre.be_java_hisp_w31_g04.model;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class Post {
+    private int userId;
+    private int id;
+    private LocalDate date;
+    private Product product;
+    private String category;
+    private Double price;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/Product.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/Product.java
@@ -1,0 +1,15 @@
+package com.mercadolibre.be_java_hisp_w31_g04.model;
+
+import lombok.Data;
+
+@Data
+public class Product {
+    private int id;
+    private String name;
+    private String type;
+    private String brand;
+    private String color;
+    private String notes;
+    private Boolean hasPromo;
+    private Double discount;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/RemoveThisModel.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/RemoveThisModel.java
@@ -1,5 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.model;
-
-public class RemoveThisModel {
-
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/User.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/User.java
@@ -1,0 +1,13 @@
+package com.mercadolibre.be_java_hisp_w31_g04.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class User {
+    private int id;
+    private String name;
+    private List<User> following;
+    private List<User> followedBy;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/User.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/model/User.java
@@ -8,6 +8,6 @@ import java.util.List;
 public class User {
     private int id;
     private String name;
-    private List<User> following;
-    private List<User> followedBy;
+    private List<Integer>following;
+    private List<Integer> followedBy;
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IProductRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IProductRepository.java
@@ -1,4 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.repository;
-
-public interface IProductRepository {
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IProductRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IProductRepository.java
@@ -1,5 +1,4 @@
 package com.mercadolibre.be_java_hisp_w31_g04.repository;
 
-public class RemoveThisRepository {
-
+public interface IProductRepository {
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IUserRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/IUserRepository.java
@@ -1,0 +1,9 @@
+package com.mercadolibre.be_java_hisp_w31_g04.repository;
+
+import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+
+import java.util.Optional;
+
+public interface IUserRepository {
+    Optional<User> getById(Integer userId);
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/ProductRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.mercadolibre.be_java_hisp_w31_g04.repository;
 
+import com.mercadolibre.be_java_hisp_w31_g04.repository.api.IProductRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/ProductRepositoryImpl.java
@@ -1,0 +1,7 @@
+package com.mercadolibre.be_java_hisp_w31_g04.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductRepositoryImpl implements IProductRepository {
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.mercadolibre.be_java_hisp_w31_g04.repository;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+import lombok.Getter;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ResourceUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class UserRepositoryImpl implements IUserRepository{
+    private List<User> listOfUsers= new ArrayList<>();
+
+    public UserRepositoryImpl() throws IOException{
+        loadDataBase();
+    }
+
+    private void loadDataBase() throws IOException {
+        File file;
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<User> users ;
+
+        file= ResourceUtils.getFile("classpath:users.json");
+        users= objectMapper.readValue(file,new TypeReference<List<User>>(){});
+
+        listOfUsers = users;
+    }
+
+    @Override
+    public Optional<User> getById(Integer userId) {
+        return listOfUsers.stream().filter(u->u.getId()==userId).findFirst();
+    }
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.repository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
-import lombok.Getter;
+import com.mercadolibre.be_java_hisp_w31_g04.repository.api.IUserRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.ResourceUtils;
 
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public class UserRepositoryImpl implements IUserRepository{
+public class UserRepositoryImpl implements IUserRepository {
     private List<User> listOfUsers= new ArrayList<>();
 
     public UserRepositoryImpl() throws IOException{

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 public class UserRepositoryImpl implements IUserRepository {

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IProductRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IProductRepository.java
@@ -1,0 +1,4 @@
+package com.mercadolibre.be_java_hisp_w31_g04.repository.api;
+
+public interface IProductRepository {
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
@@ -2,6 +2,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.repository.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 public interface IUserRepository {

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
@@ -1,4 +1,4 @@
-package com.mercadolibre.be_java_hisp_w31_g04.repository;
+package com.mercadolibre.be_java_hisp_w31_g04.repository.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IProductService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IProductService.java
@@ -1,5 +1,4 @@
 package com.mercadolibre.be_java_hisp_w31_g04.service;
 
-public class RemoveThisService {
-
+public interface IProductService {
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IProductService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IProductService.java
@@ -1,4 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.service;
-
-public interface IProductService {
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
@@ -1,7 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.service;
-
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
-
-public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId, String order);
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
@@ -3,5 +3,5 @@ package com.mercadolibre.be_java_hisp_w31_g04.service;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 
 public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId);
+    UserFollowedDto getUserFollowed(Integer userId, String order);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
@@ -1,0 +1,7 @@
+package com.mercadolibre.be_java_hisp_w31_g04.service;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+
+public interface IUserService {
+    UserFollowedDto getUserFollowed(Integer userId);
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/ProductServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/ProductServiceImpl.java
@@ -1,0 +1,7 @@
+package com.mercadolibre.be_java_hisp_w31_g04.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProductServiceImpl implements IProductService{
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/ProductServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/ProductServiceImpl.java
@@ -1,7 +1,8 @@
 package com.mercadolibre.be_java_hisp_w31_g04.service;
 
+import com.mercadolibre.be_java_hisp_w31_g04.service.api.IProductService;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ProductServiceImpl implements IProductService{
+public class ProductServiceImpl implements IProductService {
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -8,8 +8,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class UserServiceImpl implements IUserService {
@@ -18,13 +17,28 @@ public class UserServiceImpl implements IUserService {
     UserRepositoryImpl userRepositoryImpl;
 
     @Override
-    public UserFollowedDto getUserFollowed(Integer userId) {
+    public UserFollowedDto getUserFollowed(Integer userId, String order) {
         User user= userRepositoryImpl.getById(userId)
                 .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
 
         List<UserFollowedDto> followed=new ArrayList<>();
         List<User> users= user.getFollowing().stream().map(u->userRepositoryImpl.getById(u).get()).toList();
         users.forEach(user1->{followed.add(UserMapper.toUserFollowedDto(user1));});
+        if(order.equals("name_asc")) {
+            followed.sort(new Comparator<UserFollowedDto>() {
+                public int compare(UserFollowedDto obj1, UserFollowedDto obj2) {
+                    return obj1.getUser_name().compareTo(obj2.getUser_name());
+                }
+            });
+        }
+        if(order.equals("name_desc")) {
+            followed.sort(new Comparator<UserFollowedDto>() {
+                public int compare(UserFollowedDto obj2, UserFollowedDto obj1) {
+                    return obj1.getUser_name().compareTo(obj2.getUser_name());
+                }
+            });
+        }
+
 
 
 

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.service;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
@@ -55,5 +56,18 @@ public class UserServiceImpl implements IUserService {
                 .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
 
         return UserMapper.toFollowersCountDto(user, user.getFollowedBy().size());
+    }
+
+    @Override
+    public UserWithFollowersDto getUserWithFollowed(Integer userId) {
+        User user = userRepositoryImpl.getById(userId)
+                .orElseThrow(() -> new NotFoundException("No se encontró nungun usuario"));
+
+        List<UserFollowedDto> followedBy = user.getFollowedBy().stream()
+                                    .map(u-> userRepositoryImpl.getById(u).get())
+                                    .map(UserMapper::toUserFollowedDto)
+                                    .toList();
+
+        return UserMapper.toUserWithFollowedDto(user, followedBy);
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.mercadolibre.be_java_hisp_w31_g04.service;
 
+import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
+import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
 import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -43,5 +45,13 @@ public class UserServiceImpl implements IUserService {
 
 
         return new UserFollowedDto(user.getId(), user.getName(), followed);
+    }
+
+    @Override
+    public FollowersCountDto getUserFollowersCount(Integer userId) {
+        User user = userRepositoryImpl.getById(userId)
+                .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
+
+        return UserMapper.toFollowersCountDto(user, user.getFollowedBy().size());
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
+import com.mercadolibre.be_java_hisp_w31_g04.repository.api.IUserRepository;
 import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
 import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +16,10 @@ import java.util.*;
 @Service
 public class UserServiceImpl implements IUserService {
 
-    @Autowired
-    UserRepositoryImpl userRepositoryImpl;
 
+    IUserRepository userRepositoryImpl;
+
+    public UserServiceImpl(UserRepositoryImpl userRepositoryImpl){this.userRepositoryImpl = userRepositoryImpl;}
     @Override
     public UserFollowedDto getUserFollowed(Integer userId, String order) {
         User user= userRepositoryImpl.getById(userId)

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -1,0 +1,33 @@
+package com.mercadolibre.be_java_hisp_w31_g04.service;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
+import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
+import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class UserServiceImpl implements IUserService {
+
+    @Autowired
+    UserRepositoryImpl userRepositoryImpl;
+
+    @Override
+    public UserFollowedDto getUserFollowed(Integer userId) {
+        User user= userRepositoryImpl.getById(userId)
+                .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
+
+        List<UserFollowedDto> followed=new ArrayList<>();
+        List<User> users= user.getFollowing().stream().map(u->userRepositoryImpl.getById(u).get()).toList();
+        users.forEach(user1->{followed.add(UserMapper.toUserFollowedDto(user1));});
+
+
+
+        return new UserFollowedDto(user.getId(), user.getName(), followed);
+    }
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IProductService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IProductService.java
@@ -1,0 +1,4 @@
+package com.mercadolibre.be_java_hisp_w31_g04.service.api;
+
+public interface IProductService {
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -4,7 +4,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 
 public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId);
+    UserFollowedDto getUserFollowed(Integer userId,String order);
 
     FollowersCountDto getUserFollowersCount(Integer userId);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -2,9 +2,11 @@ package com.mercadolibre.be_java_hisp_w31_g04.service.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 
 public interface IUserService {
     UserFollowedDto getUserFollowed(Integer userId,String order);
 
     FollowersCountDto getUserFollowersCount(Integer userId);
+    UserWithFollowersDto getUserWithFollowed(Integer userId);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -1,0 +1,10 @@
+package com.mercadolibre.be_java_hisp_w31_g04.service.api;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+
+public interface IUserService {
+    UserFollowedDto getUserFollowed(Integer userId);
+
+    FollowersCountDto getUserFollowersCount(Integer userId);
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
@@ -1,10 +1,19 @@
 package com.mercadolibre.be_java_hisp_w31_g04.util;
 
+import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 
 public class UserMapper {
     public static UserFollowedDto toUserFollowedDto(User user) {
         return new UserFollowedDto(user.getId(), user.getName());
+    }
+
+    public static FollowersCountDto toFollowersCountDto(User user, int followers) {
+        return new FollowersCountDto(
+                user.getId(),
+                user.getName(),
+                followers
+        );
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
@@ -2,7 +2,10 @@ package com.mercadolibre.be_java_hisp_w31_g04.util;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+
+import java.util.List;
 
 public class UserMapper {
     public static UserFollowedDto toUserFollowedDto(User user) {
@@ -14,6 +17,14 @@ public class UserMapper {
                 user.getId(),
                 user.getName(),
                 followers
+        );
+    }
+
+    public static UserWithFollowersDto toUserWithFollowedDto(User user, List<UserFollowedDto> followed) {
+        return new UserWithFollowersDto(
+                user.getId(),
+                user.getName(),
+                followed
         );
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
@@ -1,0 +1,10 @@
+package com.mercadolibre.be_java_hisp_w31_g04.util;
+
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+
+public class UserMapper {
+    public static UserFollowedDto toUserFollowedDto(User user) {
+        return new UserFollowedDto(user.getId(), user.getName());
+    }
+}

--- a/src/main/resources/users.json
+++ b/src/main/resources/users.json
@@ -56,7 +56,7 @@
   {
     "id": 10,
     "name": "Jack",
-    "following": [9, 2],
+    "following": [9, 2, 3, 1, 6],
     "followedBy": [5, 6]
   }
 ]

--- a/src/main/resources/users.json
+++ b/src/main/resources/users.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": 1,
+    "name": "Alice",
+    "following": [2, 3],
+    "followedBy": [4, 5]
+  },
+  {
+    "id": 2,
+    "name": "Bob",
+    "following": [1, 6],
+    "followedBy": [1, 7]
+  },
+  {
+    "id": 3,
+    "name": "Charlie",
+    "following": [8, 5],
+    "followedBy": [1, 6]
+  },
+  {
+    "id": 4,
+    "name": "David",
+    "following": [2, 9],
+    "followedBy": [1, 3]
+  },
+  {
+    "id": 5,
+    "name": "Eve",
+    "following": [10, 3],
+    "followedBy": [2, 4]
+  },
+  {
+    "id": 6,
+    "name": "Frank",
+    "following": [5, 1],
+    "followedBy": [2, 3]
+  },
+  {
+    "id": 7,
+    "name": "Grace",
+    "following": [4, 2],
+    "followedBy": [1, 8]
+  },
+  {
+    "id": 8,
+    "name": "Hank",
+    "following": [6, 10],
+    "followedBy": [3, 7]
+  },
+  {
+    "id": 9,
+    "name": "Irene",
+    "following": [7, 1],
+    "followedBy": [4, 8]
+  },
+  {
+    "id": 10,
+    "name": "Jack",
+    "following": [9, 2],
+    "followedBy": [5, 6]
+  }
+]


### PR DESCRIPTION
This request adds an endpoint to retrieve the number of users following a seller.

The response includes the seller's user_id, user_name, and followers list.

Response example:
{
    "user_id": 1,
    "user_name": "Alice",
    "followers": [
        {
            "user_id": 4,
            "user_name": "David"
        },
        {
            "user_id": 5,
            "user_name": "Eve"
        }
    ]
}