### PR TITLE
feat: get amount of users that follow a seller user (US0003)

### DIFF
--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -1,15 +1,13 @@
 package com.mercadolibre.be_java_hisp_w31_g04.controller;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -21,7 +19,7 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/followed/list")
-    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {
+    public ResponseEntity<UserDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {
         return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId,order), HttpStatus.OK);
     }
 

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -2,12 +2,14 @@ package com.mercadolibre.be_java_hisp_w31_g04.controller;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -28,4 +30,8 @@ public class UserController {
         return new ResponseEntity<>(userServiceImpl.getUserFollowersCount(userId), HttpStatus.OK);
     }
 
+    @GetMapping("/{userId}/followers/list")
+    public ResponseEntity<UserWithFollowersDto> getUserFollowers(@PathVariable int userId){
+        return new ResponseEntity<>(userServiceImpl.getUserWithFollowed(userId), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/controller/UserController.java
@@ -5,10 +5,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.service.UserServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -18,8 +15,8 @@ public class UserController {
     UserServiceImpl userServiceImpl;
 
     @GetMapping("/{userId}/followed/list")
-    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId){
-        return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId), HttpStatus.OK);
+    public ResponseEntity<UserFollowedDto> getUserFollowed(@PathVariable Integer userId, @RequestParam(defaultValue = "name_asc") String order) {
+        return new ResponseEntity<>(userServiceImpl.getUserFollowed(userId,order), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserDto.java
@@ -4,17 +4,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.ArrayList;
 import java.util.List;
 @Data
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-public class UserFollowedDto {
+public class UserDto {
     private int user_id;
     private String user_name;
-    private List<UserFollowedDto> followed;
+    private List<UserDto> followed;
 
-    public UserFollowedDto(int id, String name) {
+    public UserDto(int id, String name) {
         this.user_id = id;
         this.user_name = name;
         followed = null;

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
@@ -1,0 +1,18 @@
+package com.mercadolibre.be_java_hisp_w31_g04.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserWithFollowersDto {
+    private int user_id;
+    private String user_name;
+    private List<UserFollowedDto> followers;
+}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/dto/UserWithFollowersDto.java
@@ -14,5 +14,5 @@ import java.util.List;
 public class UserWithFollowersDto {
     private int user_id;
     private String user_name;
-    private List<UserFollowedDto> followers;
+    private List<UserDto> followers;
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/UserRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 public class UserRepositoryImpl implements IUserRepository {

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/repository/api/IUserRepository.java
@@ -2,6 +2,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.repository.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 public interface IUserRepository {

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
@@ -1,7 +1,0 @@
-package com.mercadolibre.be_java_hisp_w31_g04.service;
-
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
-
-public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId, String order);
-}

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/IUserService.java
@@ -3,5 +3,5 @@ package com.mercadolibre.be_java_hisp_w31_g04.service;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 
 public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId);
+    UserFollowedDto getUserFollowed(Integer userId, String order);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -8,8 +8,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class UserServiceImpl implements IUserService {
@@ -18,13 +17,28 @@ public class UserServiceImpl implements IUserService {
     UserRepositoryImpl userRepositoryImpl;
 
     @Override
-    public UserFollowedDto getUserFollowed(Integer userId) {
+    public UserFollowedDto getUserFollowed(Integer userId, String order) {
         User user= userRepositoryImpl.getById(userId)
                 .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
 
         List<UserFollowedDto> followed=new ArrayList<>();
         List<User> users= user.getFollowing().stream().map(u->userRepositoryImpl.getById(u).get()).toList();
         users.forEach(user1->{followed.add(UserMapper.toUserFollowedDto(user1));});
+        if(order.equals("name_asc")) {
+            followed.sort(new Comparator<UserFollowedDto>() {
+                public int compare(UserFollowedDto obj1, UserFollowedDto obj2) {
+                    return obj1.getUser_name().compareTo(obj2.getUser_name());
+                }
+            });
+        }
+        if(order.equals("name_desc")) {
+            followed.sort(new Comparator<UserFollowedDto>() {
+                public int compare(UserFollowedDto obj2, UserFollowedDto obj1) {
+                    return obj1.getUser_name().compareTo(obj2.getUser_name());
+                }
+            });
+        }
+
 
 
 

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.mercadolibre.be_java_hisp_w31_g04.service;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
@@ -55,5 +56,18 @@ public class UserServiceImpl implements IUserService {
                 .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
 
         return UserMapper.toFollowersCountDto(user, user.getFollowedBy().size());
+    }
+
+    @Override
+    public UserWithFollowersDto getUserWithFollowed(Integer userId) {
+        User user = userRepositoryImpl.getById(userId)
+                .orElseThrow(() -> new NotFoundException("No se encontró nungun usuario"));
+
+        List<UserFollowedDto> followedBy = user.getFollowedBy().stream()
+                                    .map(u-> userRepositoryImpl.getById(u).get())
+                                    .map(UserMapper::toUserFollowedDto)
+                                    .toList();
+
+        return UserMapper.toUserWithFollowedDto(user, followedBy);
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.mercadolibre.be_java_hisp_w31_g04.service;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.exception.NotFoundException;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
@@ -9,7 +9,6 @@ import com.mercadolibre.be_java_hisp_w31_g04.repository.UserRepositoryImpl;
 import com.mercadolibre.be_java_hisp_w31_g04.repository.api.IUserRepository;
 import com.mercadolibre.be_java_hisp_w31_g04.service.api.IUserService;
 import com.mercadolibre.be_java_hisp_w31_g04.util.UserMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -22,23 +21,23 @@ public class UserServiceImpl implements IUserService {
 
     public UserServiceImpl(UserRepositoryImpl userRepositoryImpl){this.userRepositoryImpl = userRepositoryImpl;}
     @Override
-    public UserFollowedDto getUserFollowed(Integer userId, String order) {
+    public UserDto getUserFollowed(Integer userId, String order) {
         User user= userRepositoryImpl.getById(userId)
                 .orElseThrow(() -> new NotFoundException("No se encontró ningún usuario"));
 
-        List<UserFollowedDto> followed=new ArrayList<>();
+        List<UserDto> followed=new ArrayList<>();
         List<User> users= user.getFollowing().stream().map(u->userRepositoryImpl.getById(u).get()).toList();
-        users.forEach(user1->{followed.add(UserMapper.toUserFollowedDto(user1));});
+        users.forEach(user1->{followed.add(UserMapper.toUserDto(user1));});
         if(order.equals("name_asc")) {
-            followed.sort(new Comparator<UserFollowedDto>() {
-                public int compare(UserFollowedDto obj1, UserFollowedDto obj2) {
+            followed.sort(new Comparator<UserDto>() {
+                public int compare(UserDto obj1, UserDto obj2) {
                     return obj1.getUser_name().compareTo(obj2.getUser_name());
                 }
             });
         }
         if(order.equals("name_desc")) {
-            followed.sort(new Comparator<UserFollowedDto>() {
-                public int compare(UserFollowedDto obj2, UserFollowedDto obj1) {
+            followed.sort(new Comparator<UserDto>() {
+                public int compare(UserDto obj2, UserDto obj1) {
                     return obj1.getUser_name().compareTo(obj2.getUser_name());
                 }
             });
@@ -47,7 +46,7 @@ public class UserServiceImpl implements IUserService {
 
 
 
-        return new UserFollowedDto(user.getId(), user.getName(), followed);
+        return new UserDto(user.getId(), user.getName(), followed);
     }
 
     @Override
@@ -63,11 +62,11 @@ public class UserServiceImpl implements IUserService {
         User user = userRepositoryImpl.getById(userId)
                 .orElseThrow(() -> new NotFoundException("No se encontró nungun usuario"));
 
-        List<UserFollowedDto> followedBy = user.getFollowedBy().stream()
+        List<UserDto> followedBy = user.getFollowedBy().stream()
                                     .map(u-> userRepositoryImpl.getById(u).get())
-                                    .map(UserMapper::toUserFollowedDto)
+                                    .map(UserMapper::toUserDto)
                                     .toList();
 
-        return UserMapper.toUserWithFollowedDto(user, followedBy);
+        return UserMapper.toUserWithFollowersDto(user, followedBy);
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -4,7 +4,7 @@ import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
 
 public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId);
+    UserFollowedDto getUserFollowed(Integer userId,String order);
 
     FollowersCountDto getUserFollowersCount(Integer userId);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -2,9 +2,11 @@ package com.mercadolibre.be_java_hisp_w31_g04.service.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 
 public interface IUserService {
     UserFollowedDto getUserFollowed(Integer userId,String order);
 
     FollowersCountDto getUserFollowersCount(Integer userId);
+    UserWithFollowersDto getUserWithFollowed(Integer userId);
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/service/api/IUserService.java
@@ -1,11 +1,11 @@
 package com.mercadolibre.be_java_hisp_w31_g04.service.api;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 
 public interface IUserService {
-    UserFollowedDto getUserFollowed(Integer userId,String order);
+    UserDto getUserFollowed(Integer userId, String order);
 
     FollowersCountDto getUserFollowersCount(Integer userId);
     UserWithFollowersDto getUserWithFollowed(Integer userId);

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
@@ -2,7 +2,10 @@ package com.mercadolibre.be_java_hisp_w31_g04.util;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
+
+import java.util.List;
 
 public class UserMapper {
     public static UserFollowedDto toUserFollowedDto(User user) {
@@ -14,6 +17,14 @@ public class UserMapper {
                 user.getId(),
                 user.getName(),
                 followers
+        );
+    }
+
+    public static UserWithFollowersDto toUserWithFollowedDto(User user, List<UserFollowedDto> followed) {
+        return new UserWithFollowersDto(
+                user.getId(),
+                user.getName(),
+                followed
         );
     }
 }

--- a/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
+++ b/src/main/java/com/mercadolibre/be_java_hisp_w31_g04/util/UserMapper.java
@@ -1,15 +1,15 @@
 package com.mercadolibre.be_java_hisp_w31_g04.util;
 
 import com.mercadolibre.be_java_hisp_w31_g04.dto.FollowersCountDto;
-import com.mercadolibre.be_java_hisp_w31_g04.dto.UserFollowedDto;
+import com.mercadolibre.be_java_hisp_w31_g04.dto.UserDto;
 import com.mercadolibre.be_java_hisp_w31_g04.dto.UserWithFollowersDto;
 import com.mercadolibre.be_java_hisp_w31_g04.model.User;
 
 import java.util.List;
 
 public class UserMapper {
-    public static UserFollowedDto toUserFollowedDto(User user) {
-        return new UserFollowedDto(user.getId(), user.getName());
+    public static UserDto toUserDto(User user) {
+        return new UserDto(user.getId(), user.getName());
     }
 
     public static FollowersCountDto toFollowersCountDto(User user, int followers) {
@@ -20,7 +20,7 @@ public class UserMapper {
         );
     }
 
-    public static UserWithFollowersDto toUserWithFollowedDto(User user, List<UserFollowedDto> followed) {
+    public static UserWithFollowersDto toUserWithFollowersDto(User user, List<UserDto> followed) {
         return new UserWithFollowersDto(
                 user.getId(),
                 user.getName(),

--- a/src/main/resources/users.json
+++ b/src/main/resources/users.json
@@ -56,7 +56,7 @@
   {
     "id": 10,
     "name": "Jack",
-    "following": [9, 2],
+    "following": [9, 2, 3, 1, 6],
     "followedBy": [5, 6]
   }
 ]


### PR DESCRIPTION
This request adds an endpoint to retrieve the number of users following a seller.

The response includes the seller's user_id, user_name, and followers list.

Response example:
{
"user_id": 1,
"user_name": "Alice",
"followers": [
{
"user_id": 4,
"user_name": "David"
},
{
"user_id": 5,
"user_name": "Eve"
}
]
}